### PR TITLE
fix html template header

### DIFF
--- a/inst/rmarkdown/templates/data/skeleton/_template.html
+++ b/inst/rmarkdown/templates/data/skeleton/_template.html
@@ -204,7 +204,7 @@
                 <header class="heading">
                   <div class="ds_page-header">
                     $if(sgtemplates.metadata.label)$
-                      <span class="ds_page-header__label ds_content-label">Report</span>
+                      <span class="ds_page-header__label ds_content-label">$sgtemplates.metadata.label$</span>
                     $endif$
                     <h1 class="ds_page-header__title title toc-ignore">$title$</h1>
                     $if(subtitle)$


### PR DESCRIPTION
page header showed 'report' regardless of the sgtemplates.metadata.label entered in markdown